### PR TITLE
Fixes a bug where the plugin was unable to load if branch was not provided

### DIFF
--- a/src/main/java/hudson/plugins/repo/RevisionState.java
+++ b/src/main/java/hudson/plugins/repo/RevisionState.java
@@ -136,7 +136,11 @@ public class RevisionState extends SCMRevisionState implements Serializable {
 
 	@Override
 	public int hashCode() {
-		return branch.hashCode() ^ manifest.hashCode() ^ projects.hashCode();
+		if (branch != null) {
+			return branch.hashCode() ^ manifest.hashCode() ^ projects.hashCode();
+		} else {
+			return manifest.hashCode() ^ projects.hashCode();
+		}
 	}
 
 	/**


### PR DESCRIPTION
After a restart of jenkins, all repo jobs with no branch parameter were unable to load. 
This commit seems to fix that problem

Cheers

Manu
